### PR TITLE
:sparkles: Add NetBox reports and scripts volumes

### DIFF
--- a/netbox/kustomization.yaml
+++ b/netbox/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ../redis
   - configmap.yaml
   - media.yaml
+  - reports.yaml
+  - scripts.yaml
   - housekeeping.yaml
   - worker.yaml
   - server.yaml

--- a/netbox/reports.yaml
+++ b/netbox/reports.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netbox-reports
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/netbox/scripts.yaml
+++ b/netbox/scripts.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netbox-scripts
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/netbox/server.yaml
+++ b/netbox/server.yaml
@@ -25,6 +25,10 @@ spec:
           volumeMounts:
             - mountPath: /media
               name: media
+            - mountPath: /opt/netbox/netbox/reports
+              name: reports
+            - mountPath: /opt/netbox/netbox/scripts
+              name: scripts
           ports:
             - name: http
               containerPort: 8080
@@ -38,3 +42,9 @@ spec:
         - name: media
           persistentVolumeClaim:
             claimName: netbox-media
+        - name: reports
+          persistentVolumeClaim:
+            claimName: netbox-reports
+        - name: scripts
+          persistentVolumeClaim:
+            claimName: netbox-scripts

--- a/netbox/worker.yaml
+++ b/netbox/worker.yaml
@@ -25,6 +25,10 @@ spec:
           volumeMounts:
             - mountPath: /media
               name: media
+            - mountPath: /opt/netbox/netbox/reports
+              name: reports
+            - mountPath: /opt/netbox/netbox/scripts
+              name: scripts
           args:
             - /opt/netbox/venv/bin/python
             - /opt/netbox/netbox/manage.py
@@ -33,3 +37,9 @@ spec:
         - name: media
           persistentVolumeClaim:
             claimName: netbox-media
+        - name: reports
+          persistentVolumeClaim:
+            claimName: netbox-reports
+        - name: scripts
+          persistentVolumeClaim:
+            claimName: netbox-scripts


### PR DESCRIPTION
This makes the reports feature usable by providing a volume to store the uploaded reports and scripts.
    
Note this needs a shared volume between server and worker pods.