### PR TITLE
Remove ipaddr utility for templates

### DIFF
--- a/docker/extra.py
+++ b/docker/extra.py
@@ -1,7 +1,3 @@
-import sys
-sys.path.append('/etc/netbox/config/modules')
-
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import ipaddr
 from slugify import slugify, SLUG_OK
 
 def slugify_filter(input, **kwargs):
@@ -11,6 +7,5 @@ def slugify_filter(input, **kwargs):
   return slugify(input, **kwargs)
 
 JINJA2_FILTERS = {
-    'ipaddr': ipaddr,
     'slugify': slugify_filter,
 }

--- a/docker/extra_requirements.txt
+++ b/docker/extra_requirements.txt
@@ -1,2 +1,1 @@
-ansible-core
 unicode-slugify==0.1.5


### PR DESCRIPTION
This is not needed since netbox uses the `IPAddress` python type that allows all the operations we need