### PR TITLE
Build docker image on native platform

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=build /etc/unit /etc/unit
 COPY --from=build /opt/netbox/netbox/static /opt/netbox/netbox/static
 
 # Install plugins for prod
+COPY plugin_requirements.txt extra_requirements.txt /opt/netbox/
 RUN /usr/local/bin/uv pip install \
   -r /opt/netbox/plugin_requirements.txt \
   -r /opt/netbox/extra_requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,5 @@ RUN SECRET_KEY="dummydummydummydummydummydummydummydummydummydummy" /opt/netbox/
 
 FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS prod
 
+COPY --from=build /etc/unit /etc/unit
 COPY --from=build /opt/netbox /opt/netbox

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 # pinned to specific release
 ARG NETBOX_VERSION
+FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS base
+
 FROM --platform=$BUILDPLATFORM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS build
 
 # Patch NGINX Unit config
@@ -20,3 +22,9 @@ FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS prod
 
 COPY --from=build /etc/unit /etc/unit
 COPY --from=build /opt/netbox /opt/netbox
+
+# Fix native dependencies
+COPY --from=base /opt/netbox/venv /opt/netbox/venv
+RUN /usr/local/bin/uv pip install \
+  -r /opt/netbox/plugin_requirements.txt \
+  -r /opt/netbox/extra_requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,8 @@ FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS prod
 COPY --from=build /etc/unit /etc/unit
 COPY --from=build /opt/netbox/netbox/static /opt/netbox/netbox/static
 
-# Install plugins for prod
+# Install plugins and config for prod
+COPY plugins.py extra.py /etc/netbox/config/
 COPY plugin_requirements.txt extra_requirements.txt /opt/netbox/
 RUN /usr/local/bin/uv pip install \
   -r /opt/netbox/plugin_requirements.txt \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN jq -r '.settings.http.max_body_size = 52428800' /etc/unit/nginx-unit.json \
   > /etc/unit/nginx-unit-edit.json && \
   mv /etc/unit/nginx-unit-edit.json /etc/unit/nginx-unit.json
 
+# Install packages for collectstatic
 COPY plugin_requirements.txt extra_requirements.txt /opt/netbox/
 RUN /usr/local/bin/uv pip install \
   -r /opt/netbox/plugin_requirements.txt \
@@ -20,11 +21,11 @@ RUN SECRET_KEY="dummydummydummydummydummydummydummydummydummydummy" /opt/netbox/
 
 FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS prod
 
+# Copy modified files
 COPY --from=build /etc/unit /etc/unit
-COPY --from=build /opt/netbox /opt/netbox
+COPY --from=build /opt/netbox/netbox/static /opt/netbox/netbox/static
 
-# Fix native dependencies
-COPY --from=base /opt/netbox/venv /opt/netbox/venv
+# Install plugins for prod
 RUN /usr/local/bin/uv pip install \
   -r /opt/netbox/plugin_requirements.txt \
   -r /opt/netbox/extra_requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # pinned to specific release
 ARG NETBOX_VERSION
-FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS base
+FROM --platform=$BUILDPLATFORM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS build
 
 # Patch NGINX Unit config
 RUN apt-get update || true && apt-get install -yq jq
@@ -15,3 +15,7 @@ RUN /usr/local/bin/uv pip install \
 
 COPY plugins.py extra.py /etc/netbox/config/
 RUN SECRET_KEY="dummydummydummydummydummydummydummydummydummydummy" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
+
+FROM docker.io/netboxcommunity/netbox:${NETBOX_VERSION} AS prod
+
+COPY --from=build /opt/netbox /opt/netbox


### PR DESCRIPTION
This runs all execution steps that need to happen in the base image on the native platform of the builder. Only for the resulting image the resulting `/opt/netbox` folder is copied into an image for the platform we are building for, resulting in a proper multiarch image.

Hopefully this lowers the build time since there is no more emulation of different platforms involved - `COPY` steps don't need emulation